### PR TITLE
Correcting logformat

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -118,7 +118,7 @@ function logMsg($msg) {
 	if(!stringEndsWith($msg, "\n")) {
 		$msg .= "\n";
 	}		
-	echo "[".date("t.M.y H:i:s")."] {$msg}";
+	echo "[".date("d.M.y H:i:s")."] {$msg}";
 }
 
 /**


### PR DESCRIPTION
The log format is outputted with the number of days in the month, instead of the actually day.

So for example the log for today has the following entries:
[31.Jan.14 12:10:50] <Bot to server> PRIVMSG

t   Number of days in the given month
d   Day of the month, 2 digits with leading zeros
