### PR TITLE
Feature: Load plugins recursivly

### DIFF
--- a/VikingBot.php
+++ b/VikingBot.php
@@ -49,12 +49,11 @@ class VikingBot {
 		$pluginsRecDirIterator = new RecursiveDirectoryIterator('plugins');
 		foreach (new RecursiveIteratorIterator($pluginsRecDirIterator) as $filename) {
 			if(stringEndsWith($filename, '.php')) {
-				$pName = explode(DIRECTORY_SEPARATOR, $filename);
-				$pName = $pName[count($pName) - 1];
-				$pName = str_replace('.php', '', $pName);
-				$pName = str_replace('.thirdparty', '', $pName);
-				if (strpos(file_get_contents($filename), "class " . $pName . " implements pluginInterface") !== false) {
+				$content = file_get_contents($filename);
+				if (preg_match("/class (.+) implements pluginInterface/", $content, $matches)) {
+					$pName = $matches[1];
 					require($filename);
+					logMsg("Loading plugin " . $pName);
 					$this->plugins[] = new $pName();
 				}
 			}


### PR DESCRIPTION
This way one can git pull a plugin directly into the plugin folder, also we could create a thirdparty folder instead of 467722c and 0ee9871 in #19. It checks for the pluginInterface implementation so non-plugin files don't get imported, also I thought it would be a good idea to get the class name by regex instead of it's filename.
